### PR TITLE
Sanitize project name to pass bucket name validation

### DIFF
--- a/Sources/Hexaville/main.swift
+++ b/Sources/Hexaville/main.swift
@@ -67,8 +67,28 @@ class GenerateProject: Command {
             
             try FileManager.default.copyFiles(from: "\(projectRoot)/templates/SwiftProject", to: out)
             let hashId = hashids.encode(randomNumber)!
-            let bucketName = "hexaville-\(projectName.value.lowercased())-\(hashId)-bucket"
             
+            func createBucketName(from projectName: String, hashId: String) -> String {
+                let prefix = "hexaville-"
+                let suffix = "-\(hashId)-bucket"
+
+                let bucketNameMaxLength = 63
+                let maxLength = bucketNameMaxLength - (prefix + suffix).characters.count
+
+                let allowedCharacters = Set("abcdefghijklmnopqrstuvwxyz1234567890-".characters)
+                let sanitizedCharacters = projectName
+                    .lowercased()
+                    .characters
+                    .filter { allowedCharacters.contains($0) }
+                    .prefix(maxLength)
+                
+                let sanitizedName = String(sanitizedCharacters)
+                
+                return prefix + sanitizedName + suffix
+            }
+            
+            let bucketName = createBucketName(from: projectName.value, hashId: hashId)
+                
             try String(contentsOfFile: ymlPath)
                 .replacingOccurrences(of: "{{appName}}", with: projectName.value)
                 .replacingOccurrences(of: "{{bucketName}}", with: bucketName)


### PR DESCRIPTION
# Agenda

Sanitize bucket name to not raise invalid bucket name error on `$ Hexaville deploy some-project` 

# Detail

[Rules for Bucket Naming](http://docs.aws.amazon.com/AmazonS3/latest/dev/BucketRestrictions.html)

Implemented followings

- trim characters unless those are lowercase letters, numbers, and hyphens from project name.
- trim project name when the bucket name is more than 63 characters long.

## Example

```shell
$ Hexaville generate "111111111111111+++++++222222222222222ABCABCABCaaaaaaaa111111111111111+++++++222222222222222ABCABCABCaaaaaaaa" --dest ~/Desktop
```

generates 

```yml
name: 111111111111111+++++++222222222222222ABCABCABCaaaaaaaa111111111111111+++++++222222222222222ABCABCABCaaaaaaaa
service: aws
aws:
  ...
  lambda:
    bucket: hexaville-111111111111111222222222222222abcabcabcaa-epwm-bucket
    ...
```

---

```shell
$ Hexaville deploy "111111111111111+++++++222222222222222ABCABCABCaaaaaaaa111111111111111+++++++222222222222222ABCABCABCaaaaaaaa"
```

creates

<img width="1172" alt="2017-06-13 9 48 02" src="https://user-images.githubusercontent.com/904354/27061397-87e51896-501e-11e7-9680-147af5b15a12.png">
