### PR TITLE
use Docker build environment always

### DIFF
--- a/Sources/HexavilleCore/Launcher/Launcher.swift
+++ b/Sources/HexavilleCore/Launcher/Launcher.swift
@@ -107,25 +107,9 @@ public class Launcher {
     }
     
     public func launch(debug: Bool = false, shouldDiscardCache: Bool = false) throws {
-        if debug {
-            switch OS.current {
-            case .linux_x86:
-                let buildEnvProvider = LinuxBuildEnvironmentProvider()
-                let builder = SwiftBuilder()
-                _ = try builder.build(with: buildEnvProvider, config: configuration, hexavilleApplicationPath: hexavilleApplicationPath)
-                
-            case .mac:
-                let buildEnvProvider = XcodeBuildEnvironmentProvider()
-                let builder = SwiftBuilder()
-                let result = try builder.build(with: buildEnvProvider, config: configuration, hexavilleApplicationPath: hexavilleApplicationPath)
-                _ = Proc(result.destination+"/.build/debug/"+executableTarget)
-            }
-            
-        } else {
-            switch provider {
-            case .aws(let provider):
-                try launchFor(aws: provider)
-            }
+        switch provider {
+        case .aws(let provider):
+            try launchFor(aws: provider)
         }
     }
     

--- a/Sources/HexavilleCore/SwiftBuilder/SwiftBuilder.swift
+++ b/Sources/HexavilleCore/SwiftBuilder/SwiftBuilder.swift
@@ -8,19 +8,6 @@
 
 import Foundation
 
-enum OS {
-    case linux_x86
-    case mac
-    
-    static var current: OS {
-        #if os(Linux)
-            return .linux_x86
-        #else
-            return .mac
-        #endif
-    }
-}
-
 enum SwiftBuilderError: Error {
     case unsupportedPlatform(String)
     case swiftBuildFailed
@@ -40,14 +27,8 @@ class SwiftBuilder {
             return try defaultProvider.build(config: config, hexavilleApplicationPath: hexavilleApplicationPath)
         }
         
-        switch OS.current {
-        case .mac:
-            let provider = DockerBuildEnvironmentProvider()
-            return try provider.build(config: config, hexavilleApplicationPath: hexavilleApplicationPath)
-            
-        case .linux_x86:
-            throw SwiftBuilderError.unsupportedPlatform("linux_x86")
-        }
+        let provider = DockerBuildEnvironmentProvider()
+        return try provider.build(config: config, hexavilleApplicationPath: hexavilleApplicationPath)
     }
     
 }


### PR DESCRIPTION
This PR makes the swift build environment on all operating systems as Ubuntu14.04(Docker) to avoid build or runtime error depends on each architectures.