### PR TITLE
add some linux compatibilities

### DIFF
--- a/Sources/Hexaville/main.swift
+++ b/Sources/Hexaville/main.swift
@@ -89,12 +89,12 @@ class GenerateProject: Command {
             
             let bucketName = createBucketName(from: projectName.value, hashId: hashId)
                 
-            try String(contentsOfFile: ymlPath)
+            try String(contentsOfFile: ymlPath, encoding: .utf8)
                 .replacingOccurrences(of: "{{appName}}", with: projectName.value)
                 .replacingOccurrences(of: "{{bucketName}}", with: bucketName)
                 .write(toFile: ymlPath, atomically: true, encoding: .utf8)
             
-            try String(contentsOfFile: packageSwiftPath)
+            try String(contentsOfFile: packageSwiftPath, encoding: .utf8)
                 .replacingOccurrences(of: "{{appName}}", with: projectName.value)
                 .write(toFile: packageSwiftPath, atomically: true, encoding: .utf8)
             
@@ -106,7 +106,7 @@ class GenerateProject: Command {
 }
 
 func loadHexavilleFile(hexavilleFilePath: String) throws -> Yaml {
-    let ymlString = try String(contentsOfFile: hexavilleFilePath)
+    let ymlString = try String(contentsOfFile: hexavilleFilePath, encoding: .utf8)
     return try Yaml.load(ymlString)
 }
 

--- a/Sources/HexavilleCore/DotEnvParser.swift
+++ b/Sources/HexavilleCore/DotEnvParser.swift
@@ -11,7 +11,7 @@ import Foundation
 public struct DotEnvParser {
     
     public static func parse(fromFile file: String) throws -> [String: String] {
-        return try self.parse(fromString: String(contentsOfFile: file))
+        return try self.parse(fromString: String(contentsOfFile: file, encoding: .utf8))
     }
     
     public static func parse(fromString string: String) throws -> [String: String] {

--- a/Sources/HexavilleCore/FileManager.swift
+++ b/Sources/HexavilleCore/FileManager.swift
@@ -26,10 +26,10 @@ extension FileManager {
             let fullTargetPath = from+"/"+item
             let attributes = try FileManager.default.attributesOfItem(atPath: fullTargetPath)
 
-            if let fileType = attributes[FileAttributeKey.type] as? String {
+            if let fileType = attributes[FileAttributeKey.type] as? Foundation.FileAttributeType {
                 let fullDestinationPath = dest+"/"+item
                 switch fileType {
-                case FileAttributeType.typeDirectory.rawValue:
+                case FileAttributeType.typeDirectory:
                     _ = try FileManager.default.createDirectory(
                         atPath: fullDestinationPath,
                         withIntermediateDirectories: true,
@@ -37,7 +37,7 @@ extension FileManager {
                     )
                     print("created \(fullDestinationPath)")
 
-                case FileAttributeType.typeRegular.rawValue:
+                case FileAttributeType.typeRegular:
                     try Data(contentsOf: URL(string: "file://\(fullTargetPath)")!)
                         .write(to: URL(string: "file://\(fullDestinationPath)")!)
                     print("created \(fullDestinationPath)")

--- a/Sources/HexavilleCore/HexavillefileLoader/HexavillefileLoader.swift
+++ b/Sources/HexavilleCore/HexavillefileLoader/HexavillefileLoader.swift
@@ -15,7 +15,7 @@ public protocol PlatformConfigurationLoadable {
 
 public struct HexavillefileLoader {
     public static func load(hexavilleFilePath: String) throws -> Yaml {
-        let ymlString = try String(contentsOfFile: hexavilleFilePath)
+        let ymlString = try String(contentsOfFile: hexavilleFilePath, encoding: .utf8)
         return try Yaml.load(ymlString)
     }
     

--- a/Sources/HexavilleCore/Launcher/launcherProvider/AWSLauncherProvider.swift
+++ b/Sources/HexavilleCore/Launcher/launcherProvider/AWSLauncherProvider.swift
@@ -96,11 +96,11 @@ extension AWSLauncherProvider {
     fileprivate func zipPackage(buildResult: BuildResult, hexavilleApplicationPath: String, executableTarget: String) throws -> Data {
         let pkgFileName = "\(hexavilleApplicationPath)/lambda-package.zip"
         let nodejsTemplatePath = "\(projectRoot)/templates/lambda/node.js"
-        try String(contentsOfFile: "\(nodejsTemplatePath)/index.js")
+        try String(contentsOfFile: "\(nodejsTemplatePath)/index.js", encoding: .utf8)
             .replacingOccurrences(of: "{{executablePath}}", with: executableTarget)
             .write(toFile: buildResult.destination+"/index.js", atomically: true, encoding: .utf8)
         
-        try String(contentsOfFile: "\(nodejsTemplatePath)/byline.js")
+        try String(contentsOfFile: "\(nodejsTemplatePath)/byline.js", encoding: .utf8)
             .write(toFile: buildResult.destination+"/byline.js", atomically: true, encoding: .utf8)
         
         let proc = Proc("/bin/sh", ["\(projectRoot)/build-lambda-package.sh", pkgFileName, buildResult.destination, executableTarget])
@@ -545,7 +545,7 @@ extension AWSLauncherProvider {
         
         let lambdaPolicies = fetchLambdaPolicies()
         
-        let manifest = try String(contentsOfFile: hexavilleApplicationPath+"/.routing-manifest.json")
+        let manifest = try String(contentsOfFile: hexavilleApplicationPath+"/.routing-manifest.json", encoding: .utf8)
         let dict = try JSONSerialization.jsonObject(with: manifest.data, options: []) as! [String: Any]
         let manifestJSON = JSON(dict)
         

--- a/Sources/HexavilleCore/SwiftBuilder/SwiftBuildEnvironmentProvider/DockerBuildEnvironmentProvider.swift
+++ b/Sources/HexavilleCore/SwiftBuilder/SwiftBuildEnvironmentProvider/DockerBuildEnvironmentProvider.swift
@@ -11,7 +11,7 @@ import Foundation
 struct DockerBuildEnvironmentProvider: SwiftBuildEnvironmentProvider {
     
     func build(config: Configuration, hexavilleApplicationPath: String) throws -> BuildResult {
-        try String(contentsOfFile: "\(projectRoot)/Scripts/build-swift.sh")
+        try String(contentsOfFile: "\(projectRoot)/Scripts/build-swift.sh", encoding: .utf8)
             .write(toFile: "\(hexavilleApplicationPath)/build-swift.sh", atomically: true, encoding: .utf8)
         
         try String(contentsOfFile: projectRoot+"/templates/Dockerfile", encoding: .utf8)


### PR DESCRIPTION
* adding 'encoding: .utf8' argument to all of the String(contentsOfFile:) initializers. Cause it isn't implemented in recent NSString.swift(https://github.com/apple/swift-corelibs-foundation/blob/2d3b562d4efd2137e1b85758833b2d606fad1af2/Foundation/NSString.swift)
* The Linux version of value of FileAttributeKey.type in attributes is a FileAttributeTyp, not  a String