### PR TITLE
Supports lambda role creation as default behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,9 +111,7 @@ try app.run()
 
 ### Edit Hexavillefile.yml
 
-Fill `access_key_id`, `secret_access_key`, `region` and `lambda.role` in!
-
-`lambda.role` should be a `arn:aws:iam::{accountId}:role/{roleName}` format.
+Fill `access_key_id`, `secret_access_key`, `region`.
 
 ```yml
 name: test-app
@@ -125,7 +123,7 @@ aws:
   region: us-east-1
   lambda:
     bucket: xxxxxxxxx # here is generated automatically
-    role: xxxxxxxxx
+    role: xxxxxxxxx # should be a `arn:aws:iam::{accountId}:role/{roleName}`
     timout: 10
 build:
   nocache: false
@@ -133,6 +131,16 @@ swift:
   build:
     configuration: release # default is debug
 ```
+
+#### Required Properties
+
+* name
+* service
+
+if `service` is `aws`
+
+* aws
+  * lambda.bucket
 
 ### Deploy a Project
 

--- a/Sources/HexavilleCore/Configuration.swift
+++ b/Sources/HexavilleCore/Configuration.swift
@@ -32,14 +32,14 @@ public struct AWSConfiguration {
     }
     
     public struct LambdaCodeConfig {
-        public let role: String
+        public let role: String?
         public let bucket: String
         public let timeout: Int
         public let memory: Int32?
         public let vpcConfig: Lambda.VpcConfig?
         public let environment: [String : String]
         
-        public init(role: String, bucket: String, timeout: Int = 10, memory: Int32? = nil, vpcConfig: Lambda.VpcConfig? = nil, environment: [String : String] = [:]) {
+        public init(role: String?, bucket: String, timeout: Int = 10, memory: Int32? = nil, vpcConfig: Lambda.VpcConfig? = nil, environment: [String : String] = [:]) {
             self.role = role
             self.bucket = bucket
             self.timeout = timeout

--- a/Sources/HexavilleCore/HexavillefileLoader/AWSLoader.swift
+++ b/Sources/HexavilleCore/HexavillefileLoader/AWSLoader.swift
@@ -48,7 +48,7 @@ struct AWSLoader: PlatformConfigurationLoadable {
         }
         
         let lambdaCodeConfig = AWSConfiguration.LambdaCodeConfig(
-            role: config["lambda"]["role"].string ?? "",
+            role: config["lambda"]["role"].string,
             bucket: lambdaBucket,
             timeout: config["lambda"]["timout"].int ?? 10,
             vpcConfig: vpcConfig,

--- a/templates/SwiftProject/Base/Hexavillefile.yml
+++ b/templates/SwiftProject/Base/Hexavillefile.yml
@@ -7,7 +7,7 @@ aws:
   # region: us-east-1
   lambda:
     bucket: {{bucketName}}
-    role: xxxxxxxxxxxxxxxxxxxxxxxxxx
+#    role: xxxxxxxxxxxxxxxxxxxxxxxxxx
 #     vpc:
 #       subnetIds:
 #         - xxxxxx


### PR DESCRIPTION
If merge this PR, `aws.lambda.role` can be empty as default.
But user need to access AWS with user who has `AdministratorAccess`.
Of course we still supports custom `aws.lambda.role` definition