### PR TITLE
Link latest tag with version when publish binary distributions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ lambda-package.zip
 __docker_shared
 bin
 Vagrantfile
+.hexaville-version

--- a/Scripts/zip.sh
+++ b/Scripts/zip.sh
@@ -13,5 +13,6 @@ cp /usr/lib/x86_64-linux-gnu/libicuuc.so $DEST/libicuuc.so.52
 cp /usr/lib/x86_64-linux-gnu/libbsd.so $DEST/libbsd.so.0
 cp -r templates $DEST
 cp -r Scripts $DEST
+echo "$PUBLISH_VERSION" > $DEST/.hexaville-version
 cd $DEST
-zip Hexaville.zip hexaville ./*.so ./*.so.* -r templates -r Scripts
+zip Hexaville.zip hexaville .hexaville-version ./*.so ./*.so.* -r templates -r Scripts

--- a/Sources/Hexaville/main.swift
+++ b/Sources/Hexaville/main.swift
@@ -203,6 +203,14 @@ class Deploy: Command {
     }
 }
 
-let hexavilleCLI = CLI(name: "hexaville")
+func detectVersion() -> String {
+    if let path = try? Finder.findPath(childDir: "/.hexaville-version"), let version = try? String(contentsOfFile: path) {
+        return version.components(separatedBy: "\n").first ?? "Unknown"
+    }
+    
+    return "Unknown"
+}
+
+let hexavilleCLI = CLI(name: "hexaville", version: detectVersion())
 hexavilleCLI.commands = [GenerateProject(), Deploy(), RoutesCommand()]
 _ = hexavilleCLI.go()

--- a/Sources/HexavilleCore/Finder.swift
+++ b/Sources/HexavilleCore/Finder.swift
@@ -18,7 +18,7 @@ public struct Finder {
             .joined(separator: "/")
     }
     
-    internal static func findPath(childDir: String) throws -> String {
+    public static func findPath(childDir: String) throws -> String {
         let manager = FileManager.default
         
         var templatesPathCandidates: [String] = []

--- a/release-binary.sh
+++ b/release-binary.sh
@@ -28,3 +28,10 @@ cp -r Scripts .build/${SWIFT_BUILD_CONFIGURATION}
 echo "$VERSION" > .build/${SWIFT_BUILD_CONFIGURATION}/.hexaville-version
 cd .build/${SWIFT_BUILD_CONFIGURATION}
 zip $1/$MAC_DIST/Hexaville.zip hexaville .hexaville-version -r templates -r Scripts
+
+# publish
+cd $1
+git commit -am "publish $VERSION"
+git push origin master
+
+echo "version $VERSION is published!"

--- a/release-binary.sh
+++ b/release-binary.sh
@@ -7,6 +7,9 @@ if [ $# -ne 1 ]; then
   exit 1
 fi
 
+git fetch
+FULLTAG=`git describe --tags`
+VERSION="$(cut -d'-' -f1 <<<"$FULLTAG")"
 SWIFT_BUILD_CONFIGURATION=release
 MAC_DIST=bin/latest/mac
 LINUX_DIST=bin/latest/linux
@@ -16,11 +19,12 @@ mkdir -p $1/$LINUX_DIST
 
 SHARED_DIR=`pwd`/__docker_shared
 docker build --no-cache -t hexaville .
-docker run -v ${SHARED_DIR}:/Hexaville/.build hexaville
+docker run -v ${SHARED_DIR}:/Hexaville/.build -e PUBLISH_VERSION=$VERSION hexaville
 mv ${SHARED_DIR}/${SWIFT_BUILD_CONFIGURATION}/Hexaville.zip $1/$LINUX_DIST
 
 swift build -c ${SWIFT_BUILD_CONFIGURATION}
 cp -r templates .build/${SWIFT_BUILD_CONFIGURATION}
 cp -r Scripts .build/${SWIFT_BUILD_CONFIGURATION}
+echo "$VERSION" > .build/${SWIFT_BUILD_CONFIGURATION}/.hexaville-version
 cd .build/${SWIFT_BUILD_CONFIGURATION}
-zip $1/$MAC_DIST/Hexaville.zip hexaville -r templates -r Scripts
+zip $1/$MAC_DIST/Hexaville.zip hexaville .hexaville-version -r templates -r Scripts


### PR DESCRIPTION
* create .hexaville-version file that contain latest tag(version)
* show version that is written in .hexaville-version when 'hexaville version' is executed