### PR TITLE
Upgrade gcc to fix issues with missing stdatomic

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
 FROM ubuntu:14.04
 
 RUN apt-get update -y
-RUN apt-get install -y clang \
+RUN apt-get install -y software-properties-common
+RUN add-apt-repository ppa:ubuntu-toolchain-r/test
+RUN apt-get install -y clang-3.8 \
   libicu-dev \
   libbsd-dev \
   uuid-dev \
@@ -12,7 +14,11 @@ RUN apt-get install -y clang \
   libcurl4-openssl-dev \
   emacs \
   wget \
-  zip
+  zip \
+  gcc-7 g++-7
+RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 60 --slave /usr/bin/g++ g++ /usr/bin/g++-7
+RUN update-alternatives --quiet --install /usr/bin/clang clang /usr/bin/clang-3.8 100
+RUN update-alternatives --quiet --install /usr/bin/clang++ clang++ /usr/bin/clang++-3.8 100
 
 ENV SWIFT_VERSION="swift-4.1"
 ENV SWIFT_DOWNLOAD_URL=https://swift.org/builds/${SWIFT_VERSION}-release/ubuntu1404/${SWIFT_VERSION}-RELEASE/${SWIFT_VERSION}-RELEASE-ubuntu14.04.tar.gz


### PR DESCRIPTION
A library that I depend on uses `stdatomic.h`, which is missing from gcc 4.8. See https://stackoverflow.com/questions/20326604/stdatomic-h-in-gcc-4-8 for details.
I've updated the Dockerfile to install a newer version. I've verified this fixes my issue.